### PR TITLE
fix(upload): make voice input a textarea

### DIFF
--- a/frontend/src/components/SpecifyComponent.vue
+++ b/frontend/src/components/SpecifyComponent.vue
@@ -21,7 +21,7 @@
           placeholder="Happy cats abstract painting"
           variant="outlined"
         />
-        <v-text-field
+        <v-textarea
           v-model="voice"
           label="Voice"
           placeholder="Hello spamtubers..."
@@ -84,10 +84,10 @@ export default defineComponent({
   },
   updated() {
     this.errorMessage = "";
-    this.title = this.data.title || "";
-    this.description = this.data.description || "";
-    this.image = this.data.keywords.join(" ") || "";
-    this.voice = this.data.selftext || "";
+    this.title = this.data?.title || "";
+    this.description = this.data?.description || "";
+    this.image = this.data?.keywords.join(" ") || "";
+    this.voice = this.data?.selftext || "";
   },
   methods: {
     submitForm: async function () {


### PR DESCRIPTION
Change the input field for voice data from textfield to textarea.
![voice-textarea-desktop-mobile](https://user-images.githubusercontent.com/13522509/204087960-9fd0b7f3-fa17-464b-91f3-206d8c2e9ff5.jpg)
